### PR TITLE
Use last loop device from `loopdev -l`

### DIFF
--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -40,7 +40,7 @@ sfdisk ${IMG} < ${WORK}/part.sfdisk
 
 sudo kpartx -av ${IMG}
 
-LOOPDEV=$(losetup -l | grep sd.img | grep -o 'loop.')
+LOOPDEV=$(losetup -l | grep sd.img | grep -o 'loop.' | tail -n 1)
 
 sudo mkfs.fat -F32 -v -I /dev/mapper/${LOOPDEV}p1
 sudo mkfs.ext4 /dev/mapper/${LOOPDEV}p2


### PR DESCRIPTION
In my env, `make image/sd.img` failed by following error.

```
+ sudo kpartx -av /home/unasuke/src/github.com/brain-hackers/buildbrain/image/sd.img
add map loop6p1 (253:8): 0 131072 linear 7:6 2048
add map loop6p2 (253:9): 0 12154880 linear 7:6 133120
++ losetup -l
++ grep -o loop.
++ grep sd.img
+ LOOPDEV='loop6
loop4
loop5
loop3'
+ sudo mkfs.fat -F32 -v -I /dev/mapper/loop6 loop4 loop5 loop3p1
mkfs.fat 4.1 (2017-01-24)
Bad block count : loop4
Usage: mkfs.fat [-a][-A][-c][-C][-v][-I][-l bad-block-file][-b backup-boot-sector]
       [-m boot-msg-file][-n volume-name][-i volume-id]
       [-s sectors-per-cluster][-S logical-sector-size][-f number-of-FATs]
       [-h hidden-sectors][-F fat-size][-r root-dir-entries][-R reserved-sectors]
       [-M FAT-media-byte][-D drive_number]
       [--invariant]
       [--help]
       /dev/name [blocks]
make: *** [Makefile:126: image/sd.img] エラー 1
```