### PR TITLE
Add debootstrap and kpartx to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Getting Started
 1. Install dependencies.
 
     ```
-    $ sudo apt install build-essential bison flex libncurses5-dev gcc-arm-linux-gnueabi qemu-user-static
+    $ sudo apt install build-essential bison flex libncurses5-dev gcc-arm-linux-gnueabi qemu-user-static debootstrap kpartx
     ```
 
 1. Clone this repository with recursive clone enabled.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Confirmed environments
 ----------------------
 
 - Debian 10 (buster) amd64
+- Debian 11 (bullseye) amd64
 
 
 Getting Started


### PR DESCRIPTION
こんにちは。reishokuです。

amd64なDebain 11 (bullseye)では，debootstrapとkpartxがデフォルトではインストールされていないため，これら2つのパッケージを明示的にインストールする必要がありました(そうしないとスクリプトの実行が失敗します)。

debootstrapとkpartxを依存関係に追加しました。