### PR TITLE
Upgrade from buster to bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,9 @@ brainux:
 	mkdir -p brainux
 	@if [ "$(CI)" = "true" ]; then \
 		echo "I'm in CI and debootstrap without cache."; \
-		sudo debootstrap --arch=armel --foreign buster brainux/; \
+		sudo debootstrap --arch=armel --foreign bullseye brainux/; \
 	else \
-		sudo debootstrap --arch=armel --foreign buster brainux/ http://localhost:65432/debian/; \
+		sudo debootstrap --arch=armel --foreign bullseye brainux/ http://localhost:65432/debian/; \
 	fi
 	sudo cp /usr/bin/qemu-arm-static brainux/usr/bin/
 	sudo cp ./os-brainux/setup_brainux.sh brainux/

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Build Linux
 
 
 Bootstrap Debian 11 (bullseye)
-----------------------------
+------------------------------
 
 1. Run `make ldefconfig lbuild`.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Build Linux
 1. Confirm that `linux-brain/arch/arm/boot/zImage` exists.
 
 
-Bootstrap Debian 10 (buster)
+Bootstrap Debian 11 (bullseye)
 ----------------------------
 
 1. Run `make ldefconfig lbuild`.

--- a/os-brainux/override/usr/lib/os-release
+++ b/os-brainux/override/usr/lib/os-release
@@ -1,8 +1,8 @@
-PRETTY_NAME="Brainux GNU/Linux 10 (buster)"
+PRETTY_NAME="Brainux GNU/Linux 11 (bullseye)"
 NAME="Brainux GNU/Linux"
-VERSION_ID="10"
-VERSION="10 (buster)"
-VERSION_CODENAME=buster
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
 ID=debian
 HOME_URL="https://github.com/brain-hackers/README"
 SUPPORT_URL="https://github.com/brain-hackers/buildbrain"

--- a/os-brainux/setup_brainux.sh
+++ b/os-brainux/setup_brainux.sh
@@ -20,12 +20,12 @@ else
 fi
 
 cat <<EOF > /etc/apt/sources.list
-deb http://${REPO}/debian buster main contrib non-free
-deb-src http://${REPO}/debian buster main contrib non-free
-deb http://${REPO}/debian buster-updates main contrib non-free
-deb-src http://${REPO}/debian buster-updates main contrib non-free
-deb http://${REPO_SECURITY}/debian-security buster/updates main contrib non-free
-deb-src http://${REPO_SECURITY}/debian-security buster/updates main contrib non-free
+deb http://${REPO}/debian bullseye main contrib non-free
+deb-src http://${REPO}/debian bullseye main contrib non-free
+deb http://${REPO}/debian bullseye-updates main contrib non-free
+deb-src http://${REPO}/debian bullseye-updates main contrib non-free
+deb http://${REPO_SECURITY}/debian-security bullseye/updates main contrib non-free
+deb-src http://${REPO_SECURITY}/debian-security bullseye/updates main contrib non-free
 EOF
 
 cat <<EOF > /etc/apt/apt.conf.d/90-norecommend
@@ -104,11 +104,11 @@ EOF
 
 # Get wild
 cat <<EOF > /etc/apt/sources.list
-deb http://deb.debian.org/debian buster main contrib non-free
-deb-src http://deb.debian.org/debian buster main contrib non-free
-deb http://deb.debian.org/debian buster-updates main contrib non-free
-deb-src http://deb.debian.org/debian buster-updates main contrib non-free
-deb http://deb.debian.org/debian-security buster/updates main contrib non-free
-deb-src http://deb.debian.org/debian-security buster/updates main contrib non-free
+deb http://deb.debian.org/debian bullseye main contrib non-free
+deb-src http://deb.debian.org/debian bullseye main contrib non-free
+deb http://deb.debian.org/debian bullseye-updates main contrib non-free
+deb-src http://deb.debian.org/debian bullseye-updates main contrib non-free
+deb http://deb.debian.org/debian-security bullseye/updates main contrib non-free
+deb-src http://deb.debian.org/debian-security bullseye/updates main contrib non-free
 EOF
 


### PR DESCRIPTION
こんにちは。reishokuです。

このパッチはBrainuxのパッケージベースをDebian 10 busterからDebain 11 bullseyeへアップグレードするものです。

この変更を施したあと，正しくSDカードのイメージが生成できることを確認しました。