### PR TITLE
add brainux directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env
 debian
+brainux
 cache/*
 !cache/.gitkeep


### PR DESCRIPTION
brainuxフォルダがgitの管理下に入ってしまう問題の修正