### PR TITLE
README.md: add python3-pip and libyaml-dev to dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Getting Started
 1. Install dependencies.
 
     ```
-    $ sudo apt install build-essential bison flex libncurses5-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf libssl-dev bc lzop qemu-user-static debootstrap kpartx
-    $ pip install pyelftools
+    $ sudo apt install build-essential bison flex libncurses5-dev gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf libssl-dev bc lzop qemu-user-static debootstrap kpartx libyaml-dev python3-pyelftools
     ```
 
 1. Clone this repository with recursive clone enabled.


### PR DESCRIPTION
# 概要

次の変更が適用されます。
- README.md
  * 依存関係に<del>`python3-pip`と</del>`libyaml-dev`と`python3-pyelftools`が追加されます。
    - <del>Ubuntu 21.10 (impish) amd64では，`pip`コマンドが存在しないため，後続の`pip install pyelftools`がインストールされません。</del> APTで`python3-pyelftools`をインストールするので`pip`のインストールはいらないですね...
    - Ubuntu 21.10 (impish) amd64では，`libyaml-dev`をインストールしないと`yaml.h`がないと言われてzImageの生成ができません。 
    - DebianおよびUbuntuには`python3-pyelftools`パッケージがあるので，わざわざ`pip install pyelftools`する必要はありません。

-----------------------

Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~~at~~ pm.me>