### PR TITLE
Change .gitmodules URL protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/brain-hackers/boot4u
 [submodule "brainlilo"]
 	path = brainlilo
-	url = git@github.com:brain-hackers/brainlilo.git
+	url = https://github.com/brain-hackers/brainlilo.git


### PR DESCRIPTION
Brainlilo の submodule URL を、git@ から HTTPS に変更