### PR TITLE
Disable nk.bin boot loader injection by default etc.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.release_name.outputs.name }}
+          tag_name: ${{ steps.release_name.outputs.name }}-tag
           release_name: ${{ steps.release_name.outputs.name }}
           body_path: CHANGES.md
           draft: false

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -60,7 +60,8 @@ sudo mount /dev/mapper/${LOOPDEV}p2 ${WORK}/p2
 
 sudo cp ${LINUX}/arch/arm/boot/zImage ${WORK}/p1/
 sudo cp ${LINUX}/arch/arm/boot/dts/imx28-pw*.dtb ${WORK}/p1/
-sudo cp ${WORK}/*.bin ${WORK}/p1/
+sudo mkdir -p ${WORK}/p1/nk
+sudo cp ${WORK}/*.bin ${WORK}/p1/nk/
 
 make -C ${REPO}/brainlilo
 

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -51,8 +51,8 @@ sudo kpartx -av ${IMG}
 
 LOOPDEV=$(losetup -l | grep sd.img | grep -o 'loop.' | tail -n 1)
 
-sudo mkfs.fat -F32 -v -I /dev/mapper/${LOOPDEV}p1
-sudo mkfs.ext4 /dev/mapper/${LOOPDEV}p2
+sudo mkfs.fat -n boot -F32 -v -I /dev/mapper/${LOOPDEV}p1
+sudo mkfs.ext4 -L rootfs /dev/mapper/${LOOPDEV}p2
 
 mkdir -p ${WORK}/p1 ${WORK}/p2
 sudo mount -o utf8=true /dev/mapper/${LOOPDEV}p1 ${WORK}/p1


### PR DESCRIPTION
The boot sequence of all supported models is now unified since NK.BIN is disabled by default.
Enabling it again is just a one-step: move or copy all files in `nk` directory in the FAT partition to the root directory.

Creating a release on the CI is broken because of the updated (?) validation rule of GitHub releases. Tag suffix is added to fix this.