### PR TITLE
Add Docker-based macOS build workflow for the Buildroot variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ nk.bin
 image/sd*.img
 *.exe
 image/work
+buildroot_output
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,linux,windows
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,linux,windows

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,0 +1,36 @@
+ARG BUILDROOT_PLATFORM=linux/amd64
+# TODO: Update to Trixie once we catch up with upstream Buildroot.
+FROM --platform=${BUILDROOT_PLATFORM} debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    bc \
+    bison \
+    build-essential \
+    bzip2 \
+    ca-certificates \
+    cmake \
+    cpio \
+    diffutils \
+    file \
+    flex \
+    gawk \
+    git \
+    libncurses-dev \
+    libssl-dev \
+    make \
+    patch \
+    perl \
+    python3 \
+    python3-dev \
+    rsync \
+    unzip \
+    wget \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -287,61 +287,6 @@ docker-buildroot-sd-image:
 		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
 		bash -lc "make -C nkbin_maker clean all && make IMG_BUILD_JOBS=1 image/sd_buildroot.img"
 
-# Fast rootfs-only update: replace only the ext4 partition (p2) in an existing
-# sd_buildroot.img without rebuilding U-Boot (saves ~35 min per iteration).
-# Requires image/sd_buildroot.img to already exist from a prior full build.
-# Workflow for overlay-only changes:
-#   1. Edit files under os-buildroot/override/
-#   2. make docker-buildroot-rootfs        (~1 min)
-#   3. make docker-buildroot-patch-image   (~1 min)
-#   4. Flash image/sd_buildroot.img
-.PHONY:
-docker-buildroot-patch-image:
-	docker run --rm --platform linux/amd64 --privileged \
-		-v $(BUILDROOT_VOLUME):/work/buildroot_rootfs \
-		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
-		bash -lc "set -e; \
-		  KPARTX_OUTPUT=\$$(kpartx -av image/sd_buildroot.img); \
-		  echo \"\$${KPARTX_OUTPUT}\"; \
-		  LONAME=\$$(echo \"\$${KPARTX_OUTPUT}\" | sed -n 's/^add map \(loop[0-9]\+\)p2.*/\1/p' | head -1); \
-		  if [ -z \"\$${LONAME}\" ]; then echo 'Failed to detect loop device from kpartx output'; exit 1; fi; \
-		  mkdir -p /mnt/brainp2; \
-		  mount /dev/mapper/\$${LONAME}p2 /mnt/brainp2; \
-		  echo 'Wiping old rootfs...'; \
-		  rm -rf /mnt/brainp2/*; \
-		  echo 'Copying new rootfs...'; \
-		  cp -a buildroot_rootfs/. /mnt/brainp2/; \
-		  sync; \
-		  umount /mnt/brainp2; \
-		  kpartx -d image/sd_buildroot.img; \
-		  echo 'Done. Rootfs partition updated.'"
-
-# Fast kernel-only update: replace only boot partition (p1) kernel artifacts
-# in an existing sd_buildroot.img, without rebuilding rootfs or repacking image.
-# Requires image/sd_buildroot.img to already exist.
-# Workflow for kernel-only changes:
-#   1. make docker-kernel
-#   2. make docker-buildroot-patch-kernel-image
-#   3. Flash image/sd_buildroot.img
-.PHONY:
-docker-buildroot-patch-kernel-image:
-	docker run --rm --platform linux/amd64 --privileged \
-		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
-		bash -lc "set -e; \
-		  KPARTX_OUTPUT=\$$(kpartx -av image/sd_buildroot.img); \
-		  echo \"\$${KPARTX_OUTPUT}\"; \
-		  LONAME=\$$(echo \"\$${KPARTX_OUTPUT}\" | sed -n 's/^add map \(loop[0-9]\+\)p1.*/\1/p' | head -1); \
-		  if [ -z \"\$${LONAME}\" ]; then echo 'Failed to detect loop device from kpartx output'; exit 1; fi; \
-		  mkdir -p /mnt/brainp1; \
-		  mount -o utf8=true /dev/mapper/\$${LONAME}p1 /mnt/brainp1; \
-		  echo 'Updating kernel artifacts on boot partition...'; \
-		  cp -f linux-brain/arch/arm/boot/zImage /mnt/brainp1/; \
-		  cp -f linux-brain/arch/arm/boot/dts/imx28-pw*.dtb /mnt/brainp1/; \
-		  sync; \
-		  umount /mnt/brainp1; \
-		  kpartx -d image/sd_buildroot.img; \
-		  echo 'Done. Kernel artifacts updated.'"
-
 .PHONY:
 docker-buildroot-full: docker-kernel docker-buildroot-rootfs docker-buildroot-sd-image
 
@@ -360,3 +305,52 @@ docker-buildroot-output-volume-create:
 .PHONY:
 docker-buildroot-output-volume-rm:
 	docker volume rm $(BUILDROOT_OUTPUT_VOLUME) 2>/dev/null || true
+
+# ------------ Fast partition-only updates ------------
+# Requires image/sd(_buildroot).img to already exist.
+
+# Fast rootfs-only update: replace only the ext4 partition (p2) in an existing
+# sd(_buildroot).img without rebuilding U-Boot (saves ~35 min per iteration).
+# Requires image/sd(_buildroot).img to already exist from a prior full build.
+#
+# Workflow for rootfs-only changes:
+#   1. Edit files under os-(buildroot|brainux)/override/
+#      or (in the case of Buildroot) re-configure
+#   2. make docker-(buildroot-)rootfs (~1 min)
+#   3. make docker-(buildroot-)patch-rootfs-image (~1 min)
+#   4. Flash image/sd(_buildroot).img
+
+.PHONY:
+docker-patch-rootfs-image:
+	docker run --rm --platform linux/amd64 --privileged \
+	   -v $(ROOTFS_VOLUME):/work/brainux \
+	   -v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+	   ./tools/patch_image.sh rootfs-brainux image/sd.img
+
+.PHONY:
+docker-buildroot-patch-rootfs-image:
+	docker run --rm --platform linux/amd64 --privileged \
+	   -v $(BUILDROOT_VOLUME):/work/buildroot_rootfs \
+	   -v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+	   ./tools/patch_image.sh rootfs-buildroot image/sd_buildroot.img
+
+# Fast kernel-only update: replace only boot partition (p1) kernel artifacts
+# in an existing sd(_buildroot).img, w/o rebuilding rootfs or repacking image.
+#
+# Workflow for kernel-only changes:
+#   1. Edit files under `linux-brain/`
+#   2. make docker-kernel
+#   3. make docker-(buildroot-)patch-kernel-image
+#   4. Flash image/sd(_buildroot).img
+
+.PHONY:
+docker-patch-kernel-image:
+	docker run --rm --platform linux/amd64 --privileged \
+	   -v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+	   ./tools/patch_image.sh kernel image/sd.img
+
+.PHONY:
+docker-buildroot-patch-kernel-image:
+	docker run --rm --platform linux/amd64 --privileged \
+	   -v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+	   ./tools/patch_image.sh kernel image/sd_buildroot.img

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ export ARCH=arm
 
 DOCKER_IMAGE := buildbrain-builder:local
 ROOTFS_VOLUME := buildbrain-brainux-rootfs
+# Separate, leaner image for Buildroot.  Based on debian:bookworm (GCC 12)
+# which is compatible with the 2023.05-era Buildroot fork without any patches.
+BUILDROOT_DOCKER_IMAGE := buildbrain-buildroot:local
+ROOTFS_VOLUME     := buildbrain-brainux-rootfs
+BUILDROOT_VOLUME  := buildbrain-buildroot-rootfs
+BUILDROOT_OUTPUT_VOLUME := buildbrain-buildroot-output
 
 .PHONY:
 setup:
@@ -138,7 +144,7 @@ lilobuild:
 liloclean:
 	make -C ./brainlilo clean
 
-.PHONY: brainux brainux-umount-special brainux-clean
+.PHONY: brainux brainux-umount-special brainux-clean buildroot_rootfs
 brainux: 
 	@if [ "$(shell uname)" != "Linux" ]; then \
 		echo "Debootstrap is only available in Linux!"; \
@@ -182,10 +188,10 @@ brainux-clean: brainux-umount-special
 	sudo rm -rf brainux
 
 buildroot_rootfs:
-	make -C buildroot brain_imx28_defconfig
-	make -C buildroot -j 12
-	sudo mkdir -p buildroot_rootfs
-	sudo tar -C ./buildroot_rootfs -xf buildroot/output/images/rootfs.tar
+	make -C buildroot O=/work/buildroot_output brain_imx28_defconfig
+	make -C buildroot O=/work/buildroot_output
+	mkdir -p buildroot_rootfs
+	tar -C ./buildroot_rootfs -xf buildroot_output/images/rootfs.tar
 
 image/sd.img: clean_work
 	./image/build_image.sh brainux sd.img 3072
@@ -214,6 +220,10 @@ datetag:
 .PHONY:
 docker-build:
 	docker build --platform linux/amd64 -t $(DOCKER_IMAGE) -f Dockerfile .
+
+.PHONY:
+docker-buildroot-build:
+	docker build --platform linux/amd64 -t $(BUILDROOT_DOCKER_IMAGE) -f Dockerfile.buildroot .
 
 .PHONY:
 docker-uboot:
@@ -249,3 +259,105 @@ docker-volume-create:
 .PHONY:
 docker-volume-rm:
 	docker volume rm $(ROOTFS_VOLUME) 2>/dev/null || true
+
+.PHONY:
+docker-buildroot-rootfs: docker-buildroot-volume-rm docker-buildroot-volume-create docker-buildroot-output-volume-create
+	docker run --rm --platform linux/amd64 --privileged \
+		-v $(BUILDROOT_OUTPUT_VOLUME):/work/buildroot_output \
+		-v $(BUILDROOT_VOLUME):/work/buildroot_rootfs \
+		-v "$$PWD":/work -w /work $(BUILDROOT_DOCKER_IMAGE) \
+		bash -lc "make buildroot_rootfs"
+
+.PHONY:
+docker-buildroot-menuconfig:
+	docker run --rm -it --platform linux/amd64 \
+		-v "$$PWD":/work -w /work $(BUILDROOT_DOCKER_IMAGE) \
+		bash -lc "rm -rf buildroot/output/build/buildroot-config && make -C buildroot brain_imx28_defconfig && make -C buildroot menuconfig"
+
+# Run after docker-buildroot-menuconfig to persist customisations.
+.PHONY:
+docker-buildroot-savedefconfig:
+	docker run --rm --platform linux/amd64 \
+		-v "$$PWD":/work -w /work $(BUILDROOT_DOCKER_IMAGE) \
+		bash -lc "rm -rf buildroot/output/build/buildroot-config && make -C buildroot savedefconfig BR2_DEFCONFIG=configs/brain_imx28_defconfig"
+
+.PHONY:
+docker-buildroot-sd-image:
+	docker run --rm --platform linux/amd64 --privileged \
+		-v $(BUILDROOT_VOLUME):/work/buildroot_rootfs \
+		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+		bash -lc "make -C nkbin_maker clean all && make IMG_BUILD_JOBS=1 image/sd_buildroot.img"
+
+# Fast rootfs-only update: replace only the ext4 partition (p2) in an existing
+# sd_buildroot.img without rebuilding U-Boot (saves ~35 min per iteration).
+# Requires image/sd_buildroot.img to already exist from a prior full build.
+# Workflow for overlay-only changes:
+#   1. Edit files under os-buildroot/override/
+#   2. make docker-buildroot-rootfs        (~1 min)
+#   3. make docker-buildroot-patch-image   (~1 min)
+#   4. Flash image/sd_buildroot.img
+.PHONY:
+docker-buildroot-patch-image:
+	docker run --rm --platform linux/amd64 --privileged \
+		-v $(BUILDROOT_VOLUME):/work/buildroot_rootfs \
+		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+		bash -lc "set -e; \
+		  KPARTX_OUTPUT=\$$(kpartx -av image/sd_buildroot.img); \
+		  echo \"\$${KPARTX_OUTPUT}\"; \
+		  LONAME=\$$(echo \"\$${KPARTX_OUTPUT}\" | sed -n 's/^add map \(loop[0-9]\+\)p2.*/\1/p' | head -1); \
+		  if [ -z \"\$${LONAME}\" ]; then echo 'Failed to detect loop device from kpartx output'; exit 1; fi; \
+		  mkdir -p /mnt/brainp2; \
+		  mount /dev/mapper/\$${LONAME}p2 /mnt/brainp2; \
+		  echo 'Wiping old rootfs...'; \
+		  rm -rf /mnt/brainp2/*; \
+		  echo 'Copying new rootfs...'; \
+		  cp -a buildroot_rootfs/. /mnt/brainp2/; \
+		  sync; \
+		  umount /mnt/brainp2; \
+		  kpartx -d image/sd_buildroot.img; \
+		  echo 'Done. Rootfs partition updated.'"
+
+# Fast kernel-only update: replace only boot partition (p1) kernel artifacts
+# in an existing sd_buildroot.img, without rebuilding rootfs or repacking image.
+# Requires image/sd_buildroot.img to already exist.
+# Workflow for kernel-only changes:
+#   1. make docker-kernel
+#   2. make docker-buildroot-patch-kernel-image
+#   3. Flash image/sd_buildroot.img
+.PHONY:
+docker-buildroot-patch-kernel-image:
+	docker run --rm --platform linux/amd64 --privileged \
+		-v "$$PWD":/work -w /work $(DOCKER_IMAGE) \
+		bash -lc "set -e; \
+		  KPARTX_OUTPUT=\$$(kpartx -av image/sd_buildroot.img); \
+		  echo \"\$${KPARTX_OUTPUT}\"; \
+		  LONAME=\$$(echo \"\$${KPARTX_OUTPUT}\" | sed -n 's/^add map \(loop[0-9]\+\)p1.*/\1/p' | head -1); \
+		  if [ -z \"\$${LONAME}\" ]; then echo 'Failed to detect loop device from kpartx output'; exit 1; fi; \
+		  mkdir -p /mnt/brainp1; \
+		  mount -o utf8=true /dev/mapper/\$${LONAME}p1 /mnt/brainp1; \
+		  echo 'Updating kernel artifacts on boot partition...'; \
+		  cp -f linux-brain/arch/arm/boot/zImage /mnt/brainp1/; \
+		  cp -f linux-brain/arch/arm/boot/dts/imx28-pw*.dtb /mnt/brainp1/; \
+		  sync; \
+		  umount /mnt/brainp1; \
+		  kpartx -d image/sd_buildroot.img; \
+		  echo 'Done. Kernel artifacts updated.'"
+
+.PHONY:
+docker-buildroot-full: docker-kernel docker-buildroot-rootfs docker-buildroot-sd-image
+
+.PHONY:
+docker-buildroot-volume-create:
+	docker volume create $(BUILDROOT_VOLUME)
+
+.PHONY:
+docker-buildroot-volume-rm:
+	docker volume rm $(BUILDROOT_VOLUME) 2>/dev/null || true
+
+.PHONY:
+docker-buildroot-output-volume-create:
+	docker volume create $(BUILDROOT_OUTPUT_VOLUME)
+
+.PHONY:
+docker-buildroot-output-volume-rm:
+	docker volume rm $(BUILDROOT_OUTPUT_VOLUME) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ ROOTFS_VOLUME := buildbrain-brainux-rootfs
 # Separate, leaner image for Buildroot.  Based on debian:bookworm (GCC 12)
 # which is compatible with the 2023.05-era Buildroot fork without any patches.
 BUILDROOT_DOCKER_IMAGE := buildbrain-buildroot:local
-ROOTFS_VOLUME     := buildbrain-brainux-rootfs
-BUILDROOT_VOLUME  := buildbrain-buildroot-rootfs
+BUILDROOT_VOLUME := buildbrain-buildroot-rootfs
 BUILDROOT_OUTPUT_VOLUME := buildbrain-buildroot-output
 
 .PHONY:

--- a/README.md
+++ b/README.md
@@ -225,9 +225,8 @@ Other useful Docker recipes:
 
 - `make docker-uboot` to build U-Boot
 - `make docker-kernel` to build Linux kernel
-- `make docker-volume-create` / `make docker-volume-rm` to manage the Debian rootfs volume
-- `make docker-buildroot-volume-create` / `make docker-buildroot-volume-rm` to manage the Buildroot rootfs volume
-
+- `make docker-(buildroot-)volume-(create|rm)` to manage the Debian/Buildroot rootfs volume
+- `make docker-(buildroot-)patch-(kernel|rootfs)-image` to quickly update just one partition in `image/sd(_buildroot).img` (which must already exist)
 
 Known issues
 ----------------------------------------

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ You can build everything in Docker instead of preparing native Linux cross toolc
 
 For macOS, run in **stages** and use a **named volume** for the rootfs.
 
-> [!NOTE] Why a named volume for the rootfs?
+> [!NOTE]
+> **Why a named volume for the rootfs?**
+> 
 > macOS APFS (the host filesystem behind Docker bind mounts) cannot create device
 > files (`mknod`), may strip `setuid` bits, and does not faithfully preserve all
 > Linux filesystem attributes.  If the Debian rootfs is stored on APFS the result

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ If you want to customize the build of Buildroot, `cd` into `buildroot` and use t
  - `make menuconfig` to change the configuration
  - `make` to build the rootfs (`-j` option might give you extra speed)
 
+For Docker-based customization, use the interactive targets:
+
+1. `make docker-buildroot-menuconfig`
+2. `make docker-buildroot-savedefconfig` — writes `buildroot/.config` back to `buildroot/configs/brain_imx28_defconfig` so your changes are committed-safe.
+3. `make docker-buildroot-rootfs` — rebuilds the rootfs with the updated config.
+
 `image/sd_buildroot.img` target expects presence of the tarball at `buildroot/output/images/rootfs.tar`. You'll have to `clean` and rebuild every time you change the Buildroot's config before making the SD image.
 
 
@@ -157,6 +163,22 @@ You can build everything in Docker instead of preparing native Linux cross toolc
     **Note:** On macOS Docker Desktop, the combined memory footprint of kernel compilation, rootfs staging, and loop device operations can exceed the default VM allocation (~2-4 GB). Breaking into stages allows the daemon to garbage collect between steps.
 
     **Note:** `make docker-rootfs` (and thus `make docker-sd-image-full`) always deletes and recreates the named volume `buildbrain-brainux-rootfs` before building, so each rootfs build starts from a clean slate. To delete the volume manually between runs use `make docker-volume-rm`.
+
+3. *(Optional)* Build a Buildroot-based SD image instead.
+
+    ```sh
+    make docker-buildroot-full
+    ```
+
+    This builds the Linux kernel, the Buildroot rootfs, and assembles `image/sd_buildroot.img`.  Run each stage independently if preferred:
+
+    ```sh
+    make docker-kernel
+    make docker-buildroot-rootfs
+    make docker-buildroot-sd-image
+    ```
+
+    The Buildroot rootfs is stored in a separate named volume (`buildbrain-buildroot-rootfs`) for the same Linux-filesystem reasons as the Debian rootfs.  `make docker-buildroot-rootfs` always recreates it from scratch; use `make docker-buildroot-volume-rm` to wipe it manually.
 
 ### Direct Docker commands (advanced)
 
@@ -203,8 +225,8 @@ Other useful Docker recipes:
 
 - `make docker-uboot` to build U-Boot
 - `make docker-kernel` to build Linux kernel
-- `make docker-volume-create` to (re-)create the rootfs named volume
-- `make docker-volume-rm` to delete the rootfs named volume and reclaim its disk space
+- `make docker-volume-create` / `make docker-volume-rm` to manage the Debian rootfs volume
+- `make docker-buildroot-volume-create` / `make docker-buildroot-volume-rm` to manage the Buildroot rootfs volume
 
 
 Known issues

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -105,7 +105,7 @@ sudo cp ${REPO}/image/exeopener.exe "${LILO}/AppMain.exe"
 sudo mkdir -p ${WORK}/p1/loader
 sudo cp ${WORK}/lilobin/*.bin ${WORK}/p1/loader/
 
-sudo cp -ra ${REPO}/${ROOTFS}/* ${WORK}/p2/
+sudo cp -a "${REPO}/${ROOTFS}/." "${WORK}/p2/"
 
 sudo umount ${WORK}/p1 ${WORK}/p2
 sudo kpartx -d ${IMG}

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -43,7 +43,7 @@ sudo mkdir -p ${WORK}/p1/App/boot4u
 sudo cp ${REPO}/boot4u/AppMain.bin ${WORK}/p1/App/boot4u/
 sudo touch ${WORK}/p1/App/boot4u/index.din
 
-sudo cp -ra ${REPO}/brainux/* ${WORK}/p2/
+sudo cp -a "${REPO}/brainux/." "${WORK}/p2/"
 
 sudo umount ${WORK}/p1 ${WORK}/p2
 sudo kpartx -d ${IMG}

--- a/tools/patch_image.sh
+++ b/tools/patch_image.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+TYPE="$1"
+SPECIFIED_IMAGE="$2"
+
+# Parse modes and assign configurations
+case "$TYPE" in
+    "rootfs-buildroot")
+        IMAGE="${SPECIFIED_IMAGE:-image/sd_buildroot.img}"
+        PART="2"
+        MNT_DIR="/mnt/brainp2"
+        MOUNT_OPTS=""
+        SRC_DIR="buildroot_rootfs"
+        ;;
+    "rootfs-brainux")
+        IMAGE="${SPECIFIED_IMAGE:-image/sd.img}"
+        PART="2"
+        MNT_DIR="/mnt/brainp2"
+        MOUNT_OPTS=""
+        SRC_DIR="brainux"
+        ;;
+    "kernel")
+        IMAGE="${SPECIFIED_IMAGE:-image/sd.img}"
+        PART="1"
+        MNT_DIR="/mnt/brainp1"
+        MOUNT_OPTS="-o utf8=true"
+        ;;
+    *)
+        echo "Usage: $0 [kernel|rootfs-buildroot|rootfs-brainux] [optional_image_path]"
+        exit 1
+        ;;
+esac
+
+if [ ! -f "$IMAGE" ]; then
+    echo "Error: Target image '$IMAGE' does not exist."
+    exit 1
+fi
+
+echo "Mapping $IMAGE with kpartx..."
+KPARTX_OUTPUT=$(kpartx -av "$IMAGE")
+echo "$KPARTX_OUTPUT"
+
+# Extract loop device name (e.g., loop0)
+LONAME=$(echo "$KPARTX_OUTPUT" | sed -n "s/^add map \(loop[0-9]\+\)p${PART}.*/\1/p" | head -1)
+if [ -z "$LONAME" ]; then
+    echo "Failed to detect loop device from kpartx output."
+    exit 1
+fi
+
+MAPPER_DEV="/dev/mapper/${LONAME}p${PART}"
+mkdir -p "$MNT_DIR"
+
+# Cleanup trap to ensure we clean up loop devices and mounts on failure
+cleanup() {
+    echo "Cleaning up mounts and loop devices..."
+    if mountpoint -q "$MNT_DIR"; then
+        umount "$MNT_DIR"
+    fi
+    kpartx -d "$IMAGE" || true
+}
+trap cleanup EXIT
+
+echo "Mounting partition p${PART} to $MNT_DIR..."
+mount $MOUNT_OPTS "$MAPPER_DEV" "$MNT_DIR"
+
+if [[ "$TYPE" == rootfs-* ]]; then
+    echo "Wiping old rootfs..."
+    rm -rf "${MNT_DIR:?}"/*
+    echo "Copying new rootfs from $SRC_DIR..."
+    cp -a "$SRC_DIR"/. "$MNT_DIR/"
+elif [ "$TYPE" = "kernel" ]; then
+    echo "Updating kernel artifacts on boot partition..."
+    cp -f linux-brain/arch/arm/boot/zImage "$MNT_DIR/"
+    cp -f linux-brain/arch/arm/boot/dts/imx28-pw*.dtb "$MNT_DIR/"
+fi
+
+sync
+echo "Done. ${TYPE} update applied successfully to ${IMAGE}."


### PR DESCRIPTION
This PR is like #60, but for the Buildroot variant of the rootfs.

In addition, this PR also introduces time-saving shortcuts: `make docker-(buildroot-)patch-(kernel|rootfs)-image`. They replaces just one partition of your choice in an already-existing SD card image, so that you don't have to rebuild the whole kernel if you're just iterating with the rootfs, or vice versa.