### PR TITLE
fix: replace kpartx/losetup --partscan with per-partition losetup for Docker Desktop compatibility

### DIFF
--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -82,9 +82,13 @@ sfdisk ${IMG} < ${WORK}/part.sfdisk
 # losetup picks a higher number the device node may be absent.  Create it
 # with mknod (major 7) before attaching.
 losetup_attach() {
+    # losetup -f may return "/dev/loopN (lost)" when the device number is
+    # allocated by the kernel but the node is absent from /dev (common in
+    # Docker Desktop).  Strip the annotation to get the bare path, then
+    # create the node with mknod if it is still missing.
     local DEV
-    DEV=$(sudo losetup -f)
-    local NUM=${DEV#/dev/loop}
+    DEV=$(sudo losetup -f | awk '{print $1}')
+    local NUM=${DEV##/dev/loop}
     [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
     sudo losetup "${DEV}" "$@"
     echo "${DEV}"

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -75,24 +75,8 @@ EOF
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
 # Attach each partition as its own loop device using explicit offsets.
-# This avoids relying on partition sub-device creation (loopNpX) which
-# requires udev and does not work reliably in Docker containers.
-#
-# Docker Desktop only pre-populates a small set of /dev/loopN nodes, so if
-# losetup picks a higher number the device node may be absent.  Create it
-# with mknod (major 7) before attaching.
-losetup_attach() {
-    # losetup -f may return "/dev/loopN (lost)" when the device number is
-    # allocated by the kernel but the node is absent from /dev (common in
-    # Docker Desktop).  Strip the annotation to get the bare path, then
-    # create the node with mknod if it is still missing.
-    local DEV
-    DEV=$(sudo losetup -f | awk '{print $1}')
-    local NUM=${DEV##/dev/loop}
-    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
-    sudo losetup "${DEV}" "$@"
-    echo "${DEV}"
-}
+# shellcheck source=losetup_attach.sh
+source "$(dirname "$0")/losetup_attach.sh"
 
 LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
 LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -74,15 +74,14 @@ EOF
 
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
-KPARTX_OUTPUT=$(sudo kpartx -av ${IMG})
-LOOPDEV=$(echo "${KPARTX_OUTPUT}" | sed -n 's/^add map \(loop[0-9]\+\)p1.*/\1/p' | head -n 1)
+LOOPDEV=$(sudo losetup --find --show --partscan ${IMG})
 
-sudo mkfs.fat -n boot -F32 -v -I /dev/mapper/${LOOPDEV}p1
-sudo mkfs.ext4 -L rootfs /dev/mapper/${LOOPDEV}p2
+sudo mkfs.fat -n boot -F32 -v -I ${LOOPDEV}p1
+sudo mkfs.ext4 -L rootfs ${LOOPDEV}p2
 
 mkdir -p ${WORK}/p1 ${WORK}/p2
-sudo mount -o utf8=true /dev/mapper/${LOOPDEV}p1 ${WORK}/p1
-sudo mount /dev/mapper/${LOOPDEV}p2 ${WORK}/p2
+sudo mount -o utf8=true ${LOOPDEV}p1 ${WORK}/p1
+sudo mount ${LOOPDEV}p2 ${WORK}/p2
 
 echo ${BRAINUX_VERSION:-unknown} > ${WORK}/brainux_version
 sudo cp ${WORK}/brainux_version ${WORK}/p1/
@@ -108,7 +107,7 @@ sudo cp ${WORK}/lilobin/*.bin ${WORK}/p1/loader/
 sudo cp -ra ${REPO}/${ROOTFS}/* ${WORK}/p2/
 
 sudo umount ${WORK}/p1 ${WORK}/p2
-sudo kpartx -d ${IMG}
+sudo losetup -d ${LOOPDEV}
 
 rmdir ${WORK}/p1 ${WORK}/p2
 

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -75,11 +75,9 @@ EOF
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
 # Attach each partition as its own loop device using explicit offsets.
-# shellcheck source=losetup_attach.sh
-source "$(dirname "$0")/losetup_attach.sh"
-
-LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
-LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})
+LOOPATTACH=$(dirname "$0")/losetup_attach.sh
+LOOPDEV1=$(${LOOPATTACH} --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(${LOOPATTACH} --offset $((START2 * 512)) ${IMG})
 
 sudo mkfs.fat -n boot -F32 -v -I ${LOOPDEV1}
 sudo mkfs.ext4 -L rootfs ${LOOPDEV2}

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -74,14 +74,18 @@ EOF
 
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
-LOOPDEV=$(sudo losetup --find --show --partscan ${IMG})
+# Attach each partition as its own loop device using explicit offsets.
+# This avoids relying on partition sub-device creation (loopNpX) which
+# requires udev and does not work reliably in Docker containers.
+LOOPDEV1=$(sudo losetup --find --show --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(sudo losetup --find --show --offset $((START2 * 512)) ${IMG})
 
-sudo mkfs.fat -n boot -F32 -v -I ${LOOPDEV}p1
-sudo mkfs.ext4 -L rootfs ${LOOPDEV}p2
+sudo mkfs.fat -n boot -F32 -v -I ${LOOPDEV1}
+sudo mkfs.ext4 -L rootfs ${LOOPDEV2}
 
 mkdir -p ${WORK}/p1 ${WORK}/p2
-sudo mount -o utf8=true ${LOOPDEV}p1 ${WORK}/p1
-sudo mount ${LOOPDEV}p2 ${WORK}/p2
+sudo mount -o utf8=true ${LOOPDEV1} ${WORK}/p1
+sudo mount ${LOOPDEV2} ${WORK}/p2
 
 echo ${BRAINUX_VERSION:-unknown} > ${WORK}/brainux_version
 sudo cp ${WORK}/brainux_version ${WORK}/p1/
@@ -107,7 +111,7 @@ sudo cp ${WORK}/lilobin/*.bin ${WORK}/p1/loader/
 sudo cp -ra ${REPO}/${ROOTFS}/* ${WORK}/p2/
 
 sudo umount ${WORK}/p1 ${WORK}/p2
-sudo losetup -d ${LOOPDEV}
+sudo losetup -d ${LOOPDEV1} ${LOOPDEV2}
 
 rmdir ${WORK}/p1 ${WORK}/p2
 

--- a/image/build_image.sh
+++ b/image/build_image.sh
@@ -77,8 +77,21 @@ sfdisk ${IMG} < ${WORK}/part.sfdisk
 # Attach each partition as its own loop device using explicit offsets.
 # This avoids relying on partition sub-device creation (loopNpX) which
 # requires udev and does not work reliably in Docker containers.
-LOOPDEV1=$(sudo losetup --find --show --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
-LOOPDEV2=$(sudo losetup --find --show --offset $((START2 * 512)) ${IMG})
+#
+# Docker Desktop only pre-populates a small set of /dev/loopN nodes, so if
+# losetup picks a higher number the device node may be absent.  Create it
+# with mknod (major 7) before attaching.
+losetup_attach() {
+    local DEV
+    DEV=$(sudo losetup -f)
+    local NUM=${DEV#/dev/loop}
+    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
+    sudo losetup "${DEV}" "$@"
+    echo "${DEV}"
+}
+
+LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})
 
 sudo mkfs.fat -n boot -F32 -v -I ${LOOPDEV1}
 sudo mkfs.ext4 -L rootfs ${LOOPDEV2}

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -23,14 +23,18 @@ EOF
 
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
-LOOPDEV=$(sudo losetup --find --show --partscan ${IMG})
+# Attach each partition as its own loop device using explicit offsets.
+# This avoids relying on partition sub-device creation (loopNpX) which
+# requires udev and does not work reliably in Docker containers.
+LOOPDEV1=$(sudo losetup --find --show --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(sudo losetup --find --show --offset $((START2 * 512)) ${IMG})
 
-sudo mkfs.fat -F32 -v -I ${LOOPDEV}p1
-sudo mkfs.ext4 ${LOOPDEV}p2
+sudo mkfs.fat -F32 -v -I ${LOOPDEV1}
+sudo mkfs.ext4 ${LOOPDEV2}
 
 mkdir -p ${WORK}/p1 ${WORK}/p2
-sudo mount ${LOOPDEV}p1 ${WORK}/p1
-sudo mount ${LOOPDEV}p2 ${WORK}/p2
+sudo mount ${LOOPDEV1} ${WORK}/p1
+sudo mount ${LOOPDEV2} ${WORK}/p2
 
 sudo cp ${LINUX}/arch/arm/boot/zImage ${WORK}/p1/
 sudo cp ${LINUX}/arch/arm/boot/dts/imx7ulp-pwh*.dtb ${WORK}/p1/
@@ -44,7 +48,7 @@ sudo touch ${WORK}/p1/App/boot4u/index.din
 sudo cp -ra ${REPO}/brainux/* ${WORK}/p2/
 
 sudo umount ${WORK}/p1 ${WORK}/p2
-sudo losetup -d ${LOOPDEV}
+sudo losetup -d ${LOOPDEV1} ${LOOPDEV2}
 
 rmdir ${WORK}/p1 ${WORK}/p2
 

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -26,8 +26,21 @@ sfdisk ${IMG} < ${WORK}/part.sfdisk
 # Attach each partition as its own loop device using explicit offsets.
 # This avoids relying on partition sub-device creation (loopNpX) which
 # requires udev and does not work reliably in Docker containers.
-LOOPDEV1=$(sudo losetup --find --show --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
-LOOPDEV2=$(sudo losetup --find --show --offset $((START2 * 512)) ${IMG})
+#
+# Docker Desktop only pre-populates a small set of /dev/loopN nodes, so if
+# losetup picks a higher number the device node may be absent.  Create it
+# with mknod (major 7) before attaching.
+losetup_attach() {
+    local DEV
+    DEV=$(sudo losetup -f)
+    local NUM=${DEV#/dev/loop}
+    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
+    sudo losetup "${DEV}" "$@"
+    echo "${DEV}"
+}
+
+LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})
 
 sudo mkfs.fat -F32 -v -I ${LOOPDEV1}
 sudo mkfs.ext4 ${LOOPDEV2}

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -24,24 +24,8 @@ EOF
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
 # Attach each partition as its own loop device using explicit offsets.
-# This avoids relying on partition sub-device creation (loopNpX) which
-# requires udev and does not work reliably in Docker containers.
-#
-# Docker Desktop only pre-populates a small set of /dev/loopN nodes, so if
-# losetup picks a higher number the device node may be absent.  Create it
-# with mknod (major 7) before attaching.
-losetup_attach() {
-    # losetup -f may return "/dev/loopN (lost)" when the device number is
-    # allocated by the kernel but the node is absent from /dev (common in
-    # Docker Desktop).  Strip the annotation to get the bare path, then
-    # create the node with mknod if it is still missing.
-    local DEV
-    DEV=$(sudo losetup -f | awk '{print $1}')
-    local NUM=${DEV##/dev/loop}
-    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
-    sudo losetup "${DEV}" "$@"
-    echo "${DEV}"
-}
+# shellcheck source=losetup_attach.sh
+source "$(dirname "$0")/losetup_attach.sh"
 
 LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
 LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -23,16 +23,14 @@ EOF
 
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
-sudo kpartx -av ${IMG}
+LOOPDEV=$(sudo losetup --find --show --partscan ${IMG})
 
-LOOPDEV=$(losetup -l | grep sd_x1.img | grep -o 'loop.')
-
-sudo mkfs.fat -F32 -v -I /dev/mapper/${LOOPDEV}p1
-sudo mkfs.ext4 /dev/mapper/${LOOPDEV}p2
+sudo mkfs.fat -F32 -v -I ${LOOPDEV}p1
+sudo mkfs.ext4 ${LOOPDEV}p2
 
 mkdir -p ${WORK}/p1 ${WORK}/p2
-sudo mount /dev/mapper/${LOOPDEV}p1 ${WORK}/p1
-sudo mount /dev/mapper/${LOOPDEV}p2 ${WORK}/p2
+sudo mount ${LOOPDEV}p1 ${WORK}/p1
+sudo mount ${LOOPDEV}p2 ${WORK}/p2
 
 sudo cp ${LINUX}/arch/arm/boot/zImage ${WORK}/p1/
 sudo cp ${LINUX}/arch/arm/boot/dts/imx7ulp-pwh*.dtb ${WORK}/p1/
@@ -46,7 +44,7 @@ sudo touch ${WORK}/p1/App/boot4u/index.din
 sudo cp -ra ${REPO}/brainux/* ${WORK}/p2/
 
 sudo umount ${WORK}/p1 ${WORK}/p2
-sudo kpartx -d ${IMG}
+sudo losetup -d ${LOOPDEV}
 
 rmdir ${WORK}/p1 ${WORK}/p2
 

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -24,11 +24,9 @@ EOF
 sfdisk ${IMG} < ${WORK}/part.sfdisk
 
 # Attach each partition as its own loop device using explicit offsets.
-# shellcheck source=losetup_attach.sh
-source "$(dirname "$0")/losetup_attach.sh"
-
-LOOPDEV1=$(losetup_attach --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
-LOOPDEV2=$(losetup_attach --offset $((START2 * 512)) ${IMG})
+LOOPATTACH=$(dirname "$0")/losetup_attach.sh
+LOOPDEV1=$(${LOOPATTACH} --offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512)) ${IMG})
+LOOPDEV2=$(${LOOPATTACH} --offset $((START2 * 512)) ${IMG})
 
 sudo mkfs.fat -F32 -v -I ${LOOPDEV1}
 sudo mkfs.ext4 ${LOOPDEV2}

--- a/image/build_image_x1.sh
+++ b/image/build_image_x1.sh
@@ -31,9 +31,13 @@ sfdisk ${IMG} < ${WORK}/part.sfdisk
 # losetup picks a higher number the device node may be absent.  Create it
 # with mknod (major 7) before attaching.
 losetup_attach() {
+    # losetup -f may return "/dev/loopN (lost)" when the device number is
+    # allocated by the kernel but the node is absent from /dev (common in
+    # Docker Desktop).  Strip the annotation to get the bare path, then
+    # create the node with mknod if it is still missing.
     local DEV
-    DEV=$(sudo losetup -f)
-    local NUM=${DEV#/dev/loop}
+    DEV=$(sudo losetup -f | awk '{print $1}')
+    local NUM=${DEV##/dev/loop}
     [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
     sudo losetup "${DEV}" "$@"
     echo "${DEV}"

--- a/image/losetup_attach.sh
+++ b/image/losetup_attach.sh
@@ -1,0 +1,24 @@
+# losetup_attach - source this file to get the losetup_attach function.
+#
+# Usage:
+#   source "$(dirname "$0")/losetup_attach.sh"
+#   DEV=$(losetup_attach --offset <bytes> [--sizelimit <bytes>] <image>)
+#
+# Attaches an image (or a region of one) to the next free loop device and
+# prints the device path.  Works in environments where the kernel allocates
+# loop device numbers but udev has not created their /dev nodes (e.g. Docker
+# Desktop on macOS): losetup -f may return "/dev/loopN (lost)" in that case,
+# and the node is created with mknod before attaching.
+
+losetup_attach() {
+    # losetup -f may return "/dev/loopN (lost)" when the device number is
+    # allocated by the kernel but the node is absent from /dev (common in
+    # Docker Desktop).  Strip the annotation to get the bare path, then
+    # create the node with mknod if it is still missing.
+    local DEV
+    DEV=$(sudo losetup -f | awk '{print $1}')
+    local NUM=${DEV##/dev/loop}
+    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
+    sudo losetup "${DEV}" "$@"
+    echo "${DEV}"
+}

--- a/image/losetup_attach.sh
+++ b/image/losetup_attach.sh
@@ -1,24 +1,17 @@
-# losetup_attach - source this file to get the losetup_attach function.
+#!/bin/bash
+# losetup_attach.sh - attach an image (or a region of one) to a loop device.
 #
-# Usage:
-#   source "$(dirname "$0")/losetup_attach.sh"
-#   DEV=$(losetup_attach --offset <bytes> [--sizelimit <bytes>] <image>)
+# Usage: losetup_attach.sh [--offset <bytes>] [--sizelimit <bytes>] <image>
 #
-# Attaches an image (or a region of one) to the next free loop device and
-# prints the device path.  Works in environments where the kernel allocates
-# loop device numbers but udev has not created their /dev nodes (e.g. Docker
-# Desktop on macOS): losetup -f may return "/dev/loopN (lost)" in that case,
-# and the node is created with mknod before attaching.
+# Attaches the image to the next free loop device and prints the device path.
+set -euo pipefail
 
-losetup_attach() {
-    # losetup -f may return "/dev/loopN (lost)" when the device number is
-    # allocated by the kernel but the node is absent from /dev (common in
-    # Docker Desktop).  Strip the annotation to get the bare path, then
-    # create the node with mknod if it is still missing.
-    local DEV
-    DEV=$(sudo losetup -f | awk '{print $1}')
-    local NUM=${DEV##/dev/loop}
-    [ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
-    sudo losetup "${DEV}" "$@"
-    echo "${DEV}"
-}
+# losetup -f may return "/dev/loopN (lost)" when the device number is
+# allocated by the kernel but the node is absent from /dev (common in
+# Docker Desktop).  Strip the annotation to get the bare path, then
+# create the node with mknod if it is still missing.
+DEV=$(sudo losetup -f | awk '{print $1}')
+NUM=${DEV##/dev/loop}
+[ -e "${DEV}" ] || sudo mknod -m 0660 "${DEV}" b 7 "${NUM}"
+sudo losetup "${DEV}" "$@"
+echo "${DEV}"


### PR DESCRIPTION
## Problem

`make docker-buildroot-sd-image` (and `docker-sd-image`) fails inside Docker Desktop on macOS with errors like:

```
++ sudo kpartx -av /work/image/sd_buildroot.img
mount: could not find any device /dev/loop#
can't set up loop
```

or, after switching to `losetup --partscan`:

```
++ sudo losetup --find --show --partscan /work/image/sd_buildroot.img
+ LOOPDEV=/dev/loop9
+ sudo mkfs.fat -n boot -F32 -v -I /dev/loop9p1
mkfs.fat: unable to open /dev/loop9p1: No such file or directory
```

### Root cause

Both `kpartx` and `losetup --partscan` rely on the kernel creating partition sub-devices (`/dev/loopNp1`, `/dev/loopNp2`, or `/dev/mapper/loopNpX`) inside the container's `/dev`. This in turn requires either udev or devtmpfs to materialize those nodes.

This used to work under Docker Desktop's HyperKit VM, where devtmpfs propagation into privileged containers happened to expose the nodes. When Docker Desktop switched its default VM backend to **Apple's Virtualization Framework (VZ)** (default from ~4.18 onward), the VM kernel no longer creates those nodes inside the container namespace — even with `--privileged`.

An additional wrinkle: when the kernel allocates a loop device number whose `/dev` node was never created, `losetup -f` returns `/dev/loopN (lost)` with a literal ` (lost)` annotation, which further breaks any naive use of its output.

## Fix

Replace the single `losetup --partscan` (or `kpartx`) call with two independent `losetup` calls using explicit `--offset` and `--sizelimit`, one per partition. Since the partition layout is fully determined by the `sfdisk` call just before, the byte offsets are known constants:

- partition 1: `--offset $((START1 * 512)) --sizelimit $((SECTORS1 * 512))`
- partition 2: `--offset $((START2 * 512))`

No partition sub-devices are needed. Each partition is a first-class loop device, mounted and formatted directly.

The `losetup -f | awk '{print $1}'` idiom strips the ` (lost)` annotation, and a `mknod` call creates the device node if absent before attaching.

The helper is extracted into `image/losetup_attach.sh` so both `build_image.sh` and `build_image_x1.sh` share it without duplication.

## Changes

- `image/losetup_attach.sh` *(new)*: standalone script that finds the next free loop device, creates its `/dev` node if missing, attaches the image region, and prints the device path
- `image/build_image.sh`: replace `kpartx` block with two `losetup_attach.sh` calls
- `image/build_image_x1.sh`: same

The fix works on both Docker Desktop (VZ backend, macOS) and standard Linux hosts.